### PR TITLE
Upgrade to core24

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,6 +53,7 @@ parts:
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0)
       sed -e 's|Icon=transmission|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/transmission.svg|' -i gtk/transmission-gtk.desktop.in
+      sed -i '50d' gtk/transmission-gtk.metainfo.xml.in
 
   deps:
     after: [transmission]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,7 +42,6 @@ parts:
       - -DENABLE_DAEMON=OFF
       - -DINSTALL_DOC=OFF
       - -DENABLE_UTILS=OFF
-      - -DINSTALL_WEB=OFF
       - -DUSE_GTK_VERSION=4
     build-packages:
       - libcurl4-openssl-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,6 +43,7 @@ parts:
       - -DINSTALL_DOC=OFF
       - -DENABLE_UTILS=OFF
       - -DINSTALL_WEB=OFF
+      - -DUSE_GTK_VERSION=4
     build-packages:
       - libcurl4-openssl-dev
       - libminiupnpc-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,7 +48,6 @@ parts:
       - libminiupnpc-dev
       - libssl-dev
       - libnatpmp-dev
-      - libgtkmm-4.0-dev
     override-pull: |
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0)
@@ -61,8 +60,6 @@ parts:
     stage-packages:
       - libminiupnpc17
       - libnatpmp1
-      - libgtkmm-4.0-0
     prime:
       - usr/lib/*/libminiupnpc*
       - usr/lib/*/libnatpmp*
-      - usr/lib/*/libgtkmm-4.0*

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,13 +1,12 @@
 name: transmission
-base: core22
+base: core24
 adopt-info: transmission
 grade: stable
 confinement: strict
 compression: lzo
-architectures:
-  - build-on: amd64
-  - build-on: armhf
-  - build-on: arm64
+platforms:
+  amd64:
+  arm64:
 
 slots:
   transmission:
@@ -49,6 +48,7 @@ parts:
       - libminiupnpc-dev
       - libssl-dev
       - libnatpmp-dev
+      - libgtkmm-4.0-dev
     override-pull: |
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0)
@@ -60,6 +60,8 @@ parts:
     stage-packages:
       - libminiupnpc17
       - libnatpmp1
+      - libgtkmm-4.0-0
     prime:
       - usr/lib/*/libminiupnpc*
       - usr/lib/*/libnatpmp*
+      - usr/lib/*/libgtkmm-4.0*


### PR DESCRIPTION
Upgrades snap to core24,enables to use gtk4 interface for transmission.
Fixes: https://bugs.launchpad.net/transmission-snap/+bug/2030271